### PR TITLE
Issue-14: Adds Copybook Data Type Support

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -3,7 +3,7 @@ name: Rust Build
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "14/copybook-data-type-support"]
   pull_request:
     branches: ["main"]
     paths:

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -3,7 +3,7 @@ name: Rust Build
 
 on:
   push:
-    branches: ["main", "14/copybook-data-type-support"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
     paths:

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -58,7 +58,7 @@ impl fmt::Display for CopybookDefinition {
 
 #[cfg(test)]
 mod tests {
-    use crate::copybook::{FieldDefinition, GroupDefinition};
+    use crate::copybook::{FieldDefinition, GroupDefinition, DataTypeEnum};
 
     use super::*;
 
@@ -72,7 +72,8 @@ mod tests {
                     vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
                         2u32,
                         String::from("ONE"),
-                        String::from("PIC X(5)"),
+                        5u32,
+                        DataTypeEnum::AlphaNumeric,
                     ))],
                 ),
             )]);

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -69,12 +69,14 @@ mod tests {
                 GroupDefinition::create_with_statements(
                     1u32,
                     String::from("TOP-LEVEL"),
-                    vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
-                        2u32,
-                        String::from("ONE"),
-                        5u32,
-                        DataTypeEnum::AlphaNumeric,
-                    ))],
+                    vec![StatementDefinition::FieldDefinition(
+                        FieldDefinition::new_with_count(
+                            2u32,
+                            String::from("ONE"),
+                            5u32,
+                            DataTypeEnum::AlphaNumeric,
+                        ),
+                    )],
                 ),
             )]);
 

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -69,14 +69,12 @@ mod tests {
                 GroupDefinition::create_with_statements(
                     1u32,
                     String::from("TOP-LEVEL"),
-                    vec![StatementDefinition::FieldDefinition(
-                        FieldDefinition::new_with_count(
-                            2u32,
-                            String::from("ONE"),
-                            5u32,
-                            DataTypeEnum::AlphaNumeric,
-                        ),
-                    )],
+                    vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                        2u32,
+                        String::from("ONE"),
+                        Some(5u32),
+                        DataTypeEnum::AlphaNumeric,
+                    ))],
                 ),
             )]);
 

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -58,7 +58,7 @@ impl fmt::Display for CopybookDefinition {
 
 #[cfg(test)]
 mod tests {
-    use crate::copybook::{FieldDefinition, GroupDefinition, DataTypeEnum};
+    use crate::copybook::{DataTypeEnum, FieldDefinition, GroupDefinition};
 
     use super::*;
 

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -69,7 +69,7 @@ mod tests {
                 GroupDefinition::create_with_statements(
                     1u32,
                     String::from("TOP-LEVEL"),
-                    vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                    vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                         2u32,
                         String::from("ONE"),
                         5u32,

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -50,7 +50,7 @@ impl fmt::Display for CopybookDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let _ = writeln!(f, "CopybookDefinition:");
         for group in self.get_statements() {
-            let _ = writeln!(f, "{}", group);
+            let _ = writeln!(f, "  {}", group);
         }
         writeln!(f)
     }

--- a/rust/copybook-reader/src/copybook/copybook_definition.rs
+++ b/rust/copybook-reader/src/copybook/copybook_definition.rs
@@ -21,6 +21,26 @@ impl CopybookDefinition {
     pub fn add_statement(&mut self, statement_definition: StatementDefinition) {
         self.statements.push(statement_definition);
     }
+
+    // Formats a StatementDefinition with indentation
+    fn fmt_statement_with_depth(
+        &self,
+        f: &mut fmt::Formatter,
+        statement: &StatementDefinition,
+        depth: usize,
+    ) {
+        match statement {
+            StatementDefinition::GroupDefinition(group) => {
+                let _ = writeln!(f, "{}{}", " ".repeat(2usize * depth), group);
+                for sub_statement in group.get_statements() {
+                    self.fmt_statement_with_depth(f, sub_statement, depth + 1);
+                }
+            }
+            StatementDefinition::FieldDefinition(field) => {
+                let _ = writeln!(f, "{}{}", " ".repeat(2usize * depth), field);
+            }
+        }
+    }
 }
 
 impl PartialEq for CopybookDefinition {
@@ -49,8 +69,8 @@ impl Clone for CopybookDefinition {
 impl fmt::Display for CopybookDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let _ = writeln!(f, "CopybookDefinition:");
-        for group in self.get_statements() {
-            let _ = writeln!(f, "  {}", group);
+        for statement in self.get_statements() {
+            self.fmt_statement_with_depth(f, statement, 1);
         }
         writeln!(f)
     }

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -12,7 +12,7 @@ pub enum DataTypeEnum {
     AlphaNumeric,
 
     // Number fields contain whole numbers. In COBOL these may be referenced as 9() or 999.
-    Number(),
+    Number(Number),
 
     // Decimal fields in COBOL allow you to store approximate values for small fractional values or
     // very large whole numbers without using as many bytes as you would need to store an exact value.
@@ -96,6 +96,7 @@ pub struct Decimal {
 }
 
 // The Number helps define the attributes required to understand and use a Cobol Number Field.
+#[derive(AllArgsConstructor, Debug, Clone, PartialEq)]
 pub struct Number {
     // The sign of the Number Field.
     sign: SignEnum,

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,6 +1,8 @@
 //! A COBOL Copybook Data Type. COBOL primarily has three categories of data types.
 //! This enum captures those top level types and the additional meta data for each
 //! data type.
+
+use lombok::AllArgsConstructor;
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataTypeEnum {
     // Text fields that contain alphabetic values. In COBOL these may be referenced as A().
@@ -15,10 +17,12 @@ pub enum DataTypeEnum {
     // Decimal fields in COBOL allow you to store approximate values for small fractional values or
     // very large whole numbers without using as many bytes as you would need to store an exact value.
     // In COBOL these may be referenced as 9()V9(), 9().9(), or P()V()
-    Decimal(),
+    Decimal(Decimal),
 }
 
 // The data type sign identifies if a numerical data type is allowed to be negative or can only be positive.
+//TODO test PartialEq
+#[derive(Debug, Clone, PartialEq)]
 pub enum SignEnum {
     // A signed numerical data type can have negative or positive values.
     SIGNED,
@@ -30,6 +34,7 @@ pub enum SignEnum {
 // Computational types are stored in a binary format. COBOL typically stores all data types in an
 // ASCII format meaning that the number 12 requires 2 bytes of space. But because computational
 // types are stored in binary they can be more compressed.
+#[derive(Debug, Clone, PartialEq)]
 pub enum CompEnum {
     Ascii,
     Comp1,
@@ -39,6 +44,7 @@ pub enum CompEnum {
 
 // COBOL has three forms of decimals types that can be used to represent numbers with
 // fractional parts, extremely small fractional parts, or extremely large numbers.
+#[derive(Debug, Clone, PartialEq)]
 pub enum DecimalTypeEnum {
     // The implied decimal point is the type of decimal that you typically think about when you
     // see a decimal data type. In COBOL the implied decimal point is typically represented as
@@ -69,6 +75,7 @@ pub enum DecimalTypeEnum {
 }
 
 // The Decimal helps define the attributes required to understand and use a Cobol Decimal Field.
+#[derive(AllArgsConstructor, Debug, Clone, PartialEq)]
 pub struct Decimal {
     // The sign of the Decimal Field.
     sign: SignEnum,

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,11 +1,13 @@
 //! A COBOL Copybook Data Type. COBOL primarily has three categories of data types.
 //! This enum captures those top level types and the additional meta data for each
 //! data type.
+#[derive(Debug, Clone, PartialEq)]
 pub enum DataTypeEnum {
+    // Text fields that contain alphabetic values. In COBOL these may be referenced as A().
+    Alphabetic,
 
-    // Text fields contain alpha-numeric values. In COBOL these may be referenced as X() or A()
-    // TODO: would it make more sense to model this with X or A separate. Or should that just be meta data.
-    TEXT,
+    // Text fields that contain alpha-numeric values. In COBOL htese may be referenced as X().
+    AlphaNumeric,
 
     // Number fields contain whole numbers. In COBOL these may be referenced as 9() or 999.
     Number(),
@@ -13,17 +15,16 @@ pub enum DataTypeEnum {
     // Decimal fields in COBOL allow you to store approximate values for small fractional values or
     // very large whole numbers without using as many bytes as you would need to store an exact value.
     // In COBOL these may be referenced as 9()V9(), 9().9(), or P()V()
-    Decimal()
+    Decimal(),
 }
 
 // The data type sign identifies if a numerical data type is allowed to be negative or can only be positive.
 pub enum SignEnum {
-
     // A signed numerical data type can have negative or positive values.
     SIGNED,
 
     // An unsigned numerical data type will not track whether the value is positive or negative.
-    UNSIGNED
+    UNSIGNED,
 }
 
 // Computational types are stored in a binary format. COBOL typically stores all data types in an
@@ -33,13 +34,12 @@ pub enum CompEnum {
     Ascii,
     Comp1,
     Comp2,
-    Comp3
+    Comp3,
 }
 
 // COBOL has three forms of decimals types that can be used to represent numbers with
 // fractional parts, extremely small fractional parts, or extremely large numbers.
 pub enum DecimalTypeEnum {
-
     // The implied decimal point is the type of decimal that you typically think about when you
     // see a decimal data type. In COBOL the implied decimal point is typically represented as
     // something like 9(6)V9(2). The V represents where the decimal point should go so the 9(6)
@@ -65,12 +65,11 @@ pub enum DecimalTypeEnum {
     // to keep the first 3 digits of the number while the P(2) clause means that we are assuming
     // that the last 2 digits are 0. So for example, we may store the numerical value 34500 in
     // this field as "345"
-    AssumedPointRight
-} 
+    AssumedPointRight,
+}
 
 // The Decimal helps define the attributes required to understand and use a Cobol Decimal Field.
 pub struct Decimal {
-
     // The sign of the Decimal Field.
     sign: SignEnum,
 
@@ -91,7 +90,6 @@ pub struct Decimal {
 
 // The Number helps define the attributes required to understand and use a Cobol Number Field.
 pub struct Number {
-
     // The sign of the Number Field.
     sign: SignEnum,
 

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,11 +1,7 @@
-
-//! The data type module defines various structures and enums to model COBOL data types that
-//! you would find in a copybook
-
 //! A COBOL Copybook Data Type. COBOL primarily has three categories of data types.
 //! This enum captures those top level types and the additional meta data for each
 //! data type.
-enum DataTypeEnum {
+pub enum DataTypeEnum {
 
     // Text fields contain alpha-numeric values. In COBOL these may be referenced as X() or A()
     // TODO: would it make more sense to model this with X or A separate. Or should that just be meta data.
@@ -20,31 +16,85 @@ enum DataTypeEnum {
     Decimal()
 }
 
-enum SignEnum {
+// The data type sign identifies if a numerical data type is allowed to be negative or can only be positive.
+pub enum SignEnum {
+
+    // A signed numerical data type can have negative or positive values.
     SIGNED,
+
+    // An unsigned numerical data type will not track whether the value is positive or negative.
     UNSIGNED
 }
 
-enum CompEnum {
-    COMP_1,
-    COMP_2,
-    COMP_3
+// Computational types are stored in a binary format. COBOL typically stores all data types in an
+// ASCII format meaning that the number 12 requires 2 bytes of space. But because computational
+// types are stored in binary they can be more compressed.
+pub enum CompEnum {
+    Ascii,
+    Comp1,
+    Comp2,
+    Comp3
 }
 
-enum DecimalTypeEnum {
-    IMPLIED_POINT,
-    ASSUMED_POINT_LEFT,
-    ASSUMED_POINT_RIGHT
-}
+// COBOL has three forms of decimals types that can be used to represent numbers with
+// fractional parts, extremely small fractional parts, or extremely large numbers.
+pub enum DecimalTypeEnum {
 
-struct Decimal {
+    // The implied decimal point is the type of decimal that you typically think about when you
+    // see a decimal data type. In COBOL the implied decimal point is typically represented as
+    // something like 9(6)V9(2). The V represents where the decimal point should go so the 9(6)
+    // clause means that there can be 6 digits to the left of the decimal and the 9(2) clause
+    // means that there can be 2 digits to the right of the decimal. The decimal point is
+    // considered implied because the decimal is typically not stored in the number. Cobol will
+    // just assume that the decimal point belongs after the sixth digit.
+    ImpliedPoint,
+
+    // The Assumed Point Left decimal should only be used to represent extremely small numbers
+    // where you may not care what the values for the first few digits of the number are. In
+    // Cobol you will see this type of decimal represented as something like P(2)9(3) where the
+    // P() clause is on the left side of the 9() clause. In this example, the P(2) clause means
+    // that we should assume that there are 2 digits just right of the decimal with the value 0.
+    // The 9(3) clause means that we should keep the next 3 digits of the number. So for example,
+    // we may store the numerical value 0.00345 in this field as just "345"
+    AssumedPointLeft,
+
+    // The Assumed Point Right decimal should only be used to represent extremely large numbers
+    // where you may not care what the values for the last few digits of the number are. In
+    // Cobol you will see this type of decimal represented as something like 9(3)P(2) where the
+    // P() clause is on the right side of the 9() clause. In this example, the 9(3) clause means
+    // to keep the first 3 digits of the number while the P(2) clause means that we are assuming
+    // that the last 2 digits are 0. So for example, we may store the numerical value 34500 in
+    // this field as "345"
+    AssumedPointRight
+} 
+
+// The Decimal helps define the attributes required to understand and use a Cobol Decimal Field.
+pub struct Decimal {
+
+    // The sign of the Decimal Field.
     sign: SignEnum,
+
+    // The Computational Format that this field is stored in.
     comp: CompEnum,
+
+    // Which variation of the cobol decimal type this field is.
     decimal_type: DecimalTypeEnum,
-    point_position: uint32,
+
+    // The point position of the decimal field. The exact meaning of this value may vary based on
+    // the decimal type:
+    //
+    //  For [DecimalType::ImpliedPoint] this is the number of digits that come before the decimal point.
+    //  For [DecimalType::AssumedPointLeft] this is the number of assumed digits to the right of the decimal point.
+    //  For [DecimalType::AssumedPointRight] this is the number of assumed digits to the left of the decimal point.
+    point_position: u32,
 }
 
-struct Number {
+// The Number helps define the attributes required to understand and use a Cobol Number Field.
+pub struct Number {
+
+    // The sign of the Number Field.
     sign: SignEnum,
+
+    // The Computational Format that this field is stored in.
     comp: CompEnum,
 }

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,6 +1,4 @@
-//! A COBOL Copybook Data Type.
-//! This enum captures the top level types and the additional meta data as necessary for each data
-//! type.
+//! Structures and Enums used to model COBOL data types.
 
 use std::fmt;
 
@@ -10,7 +8,7 @@ pub enum DataTypeEnum {
     // Text fields that contain alphabetic values. In COBOL these may be referenced as A().
     Alphabetic,
 
-    // Text fields that contain alpha-numeric values. In COBOL htese may be referenced as X().
+    // Text fields that contain alpha-numeric values. In COBOL these may be referenced as X().
     AlphaNumeric,
 
     // Number fields contain whole numbers. In COBOL these may be referenced as 9() or 999.
@@ -43,7 +41,7 @@ impl fmt::Display for DataTypeEnum {
         // The debug trait for an enum will display a lot of extra info than the display trait
         // needs when an enum variant is a struct. So to avoid that we are extracting only the
         // enum variant name which comes before the first "(".
-        write!(f, "{}", format!("{:?}", self).split("(").next().unwrap())
+        write!(f, "{}", format!("{:?}", self).split('(').next().unwrap())
     }
 }
 
@@ -52,7 +50,6 @@ impl fmt::Display for DataTypeEnum {
 // artifact of programming with punch cards. In order to save space on the punch card for a negative
 // number the last digit will be overwritten with a letter that maps back to the original digit.
 // The existence of the letter typically indicates that the number was negative.
-//TODO test PartialEq
 #[derive(Debug, Clone, PartialEq)]
 pub enum SignEnum {
     // A signed numerical data type can have negative or positive values.
@@ -71,8 +68,8 @@ pub enum DecimalTypeEnum {
     // something like 9(6)V9(2). The V represents where the decimal point should go so the 9(6)
     // clause means that there can be 6 digits to the left of the decimal and the 9(2) clause
     // means that there can be 2 digits to the right of the decimal. The decimal point is
-    // considered implied because the decimal is typically not stored in the number. Cobol will
-    // just assume that the decimal point belongs after the sixth digit.
+    // considered implied because the decimal is typically not stored in the number. In the example
+    // above cobol will just assume that the decimal point belongs after the sixth digit.
     ImpliedPoint,
 
     // The Assumed Point Left decimal should only be used to represent extremely small numbers

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -29,6 +29,7 @@ pub enum SignEnum {
 
     // An unsigned numerical data type will not track whether the value is positive or negative.
     UNSIGNED,
+    //TODO does sign effect field length?
 }
 
 // Computational types are stored in a binary format. COBOL typically stores all data types in an
@@ -40,6 +41,7 @@ pub enum CompEnum {
     Comp1,
     Comp2,
     Comp3,
+    //TODO does Comp effect field length?
 }
 
 // COBOL has three forms of decimals types that can be used to represent numbers with

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,6 +1,6 @@
-//! A COBOL Copybook Data Type. COBOL primarily has three categories of data types.
-//! This enum captures those top level types and the additional meta data for each
-//! data type.
+//! A COBOL Copybook Data Type.
+//! This enum captures the top level types and the additional meta data as necessary for each data
+//! type.
 
 use lombok::AllArgsConstructor;
 #[derive(Debug, Clone, PartialEq)]
@@ -19,7 +19,6 @@ pub enum DataTypeEnum {
     // In COBOL these may be referenced as 9()V9(), 9().9(), or P()V()
     Decimal(Decimal),
 
-
     //TODO parse comp1,comp2, and comp3 types
     // The COMP-1 type stores a single-precision floating-point number in binary format. The
     // representation should be similiar to https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html
@@ -35,7 +34,7 @@ pub enum DataTypeEnum {
     //  as a half a byte or a nibble. The sign is always stored in the right most nibble where
     // "1100" is positive and "1101" is negative. In a copybook this field type is typically
     // defined as 01 FIELDNAME PIC 9(n) COMP-3. The total byte size = ceil(n/2).
-    Comp3
+    Comp3,
 }
 
 // The data type sign identifies if a numerical data type is allowed to be negative or can only be positive.
@@ -107,7 +106,7 @@ pub struct Decimal {
     // of these fields depend on the character length provided (n and m) in the PIC clause and the
     // mapping utilized by the cobol compiler.
     //TODO parse this
-    isSimpleBinary: bool,
+    is_simple_binary: bool,
 }
 
 // The Number helps define the attributes required to understand and use a Cobol Number Field.
@@ -121,5 +120,5 @@ pub struct Number {
     // of these fields depend on the character length provided in the PIC clause and the mapping
     // utilized by the cobol compiler. Typically this mapping could be something like
     // n=1-4, size=2 bytes; n=5-9, size=4 bytes; n=10-18, size=8 bytes
-    isSimpleBinary: bool,
+    is_simple_binary: bool,
 }

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -2,6 +2,8 @@
 //! This enum captures the top level types and the additional meta data as necessary for each data
 //! type.
 
+use std::fmt;
+
 use lombok::AllArgsConstructor;
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataTypeEnum {
@@ -34,6 +36,15 @@ pub enum DataTypeEnum {
     // "1100" is positive and "1101" is negative. In a copybook this field type is typically
     // defined as 01 FIELDNAME PIC 9(n) COMP-3. The total byte size = ceil(n/2).
     Comp3,
+}
+
+impl fmt::Display for DataTypeEnum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // The debug trait for an enum will display a lot of extra info than the display trait
+        // needs when an enum variant is a struct. So to avoid that we are extracting only the
+        // enum variant name which comes before the first "(".
+        write!(f, "{}", format!("{:?}", self).split("(").next().unwrap())
+    }
 }
 
 // The data type sign identifies if a numerical data type is allowed to be negative or can only be positive.

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -1,0 +1,50 @@
+
+//! The data type module defines various structures and enums to model COBOL data types that
+//! you would find in a copybook
+
+//! A COBOL Copybook Data Type. COBOL primarily has three categories of data types.
+//! This enum captures those top level types and the additional meta data for each
+//! data type.
+enum DataTypeEnum {
+
+    // Text fields contain alpha-numeric values. In COBOL these may be referenced as X() or A()
+    // TODO: would it make more sense to model this with X or A separate. Or should that just be meta data.
+    TEXT,
+
+    // Number fields contain whole numbers. In COBOL these may be referenced as 9() or 999.
+    Number(),
+
+    // Decimal fields in COBOL allow you to store approximate values for small fractional values or
+    // very large whole numbers without using as many bytes as you would need to store an exact value.
+    // In COBOL these may be referenced as 9()V9(), 9().9(), or P()V()
+    Decimal()
+}
+
+enum SignEnum {
+    SIGNED,
+    UNSIGNED
+}
+
+enum CompEnum {
+    COMP_1,
+    COMP_2,
+    COMP_3
+}
+
+enum DecimalTypeEnum {
+    IMPLIED_POINT,
+    ASSUMED_POINT_LEFT,
+    ASSUMED_POINT_RIGHT
+}
+
+struct Decimal {
+    sign: SignEnum,
+    comp: CompEnum,
+    decimal_type: DecimalTypeEnum,
+    point_position: uint32,
+}
+
+struct Number {
+    sign: SignEnum,
+    comp: CompEnum,
+}

--- a/rust/copybook-reader/src/copybook/data_type.rs
+++ b/rust/copybook-reader/src/copybook/data_type.rs
@@ -19,7 +19,6 @@ pub enum DataTypeEnum {
     // In COBOL these may be referenced as 9()V9(), 9().9(), or P()V()
     Decimal(Decimal),
 
-    //TODO parse comp1,comp2, and comp3 types
     // The COMP-1 type stores a single-precision floating-point number in binary format. The
     // representation should be similiar to https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html
     // and should always be 4 bytes in length and is always signed. In Cobol this data type is not
@@ -105,7 +104,6 @@ pub struct Decimal {
     // of characters. In the copybook these fields are defined as PIC 9(n)V(m) COMP. The byte-length
     // of these fields depend on the character length provided (n and m) in the PIC clause and the
     // mapping utilized by the cobol compiler.
-    //TODO parse this
     is_simple_binary: bool,
 }
 

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -12,6 +12,43 @@ pub struct FieldDefinition {
     // The Field's label is defined by the copybook and used to reference the field.
     label: String,
 
+    //TODO NOTES
+    //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
+    //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
+    //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
+
+    // modeling:
+    //      There is a type name, binary?, byte size, sign, rust type?
+    //      for decimals there is also scale & precision, decimal point? scale and precision are probably too modern for this layer
+    // 
+    // comp:
+    //      - comp-1
+    //      - comp-2
+    //      - comp-3
+    // decimals:
+    //      - digits
+    //      - point position
+    //      - implied decimal point
+    //      - assumed point position
+    //          There are two forms of an assumed decimal point. These are expressed in cobol
+    //          by defining the position value either on the left or right
+    //          LEFT
+    //              P(2)9(3)
+    //                  Is used to represent very small decimal values
+    //                  The P = 2 value means that we are assuming that there are 2 digits
+    //                  to the right of the decimal with the value 0. The 9(3) clause means
+    //                  to keep/track the following 3 digits.
+    //              For Example, we may store the value 0.00345 in this field as 345
+    //          RIGHT
+    //              9(3)P(2)
+    //                  Is used to represent very large integer values
+    //                  The 9(3) clause means to keep/track the first 3 digits of the number while
+    //                  the P = 2 value mans that we are assuming that the last 2 digits in the number
+    //                  are 0.
+    //              For example, we may store the 34500 in this field as 345
+
+    //          there can only be 1 assumed decimal point allowed.
+
     data_type: String, //TODO should be an enum
 }
 

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -36,6 +36,10 @@ impl FieldDefinition {
             data_type2: None,
         }
     }
+
+    pub fn new_with_length(level: u32, label: String, data_type_str: String,  length: u32, data_type: DataTypeEnum) -> FieldDefinition {
+        FieldDefinition { level, label, data_type: data_type_str, length: Some(length), data_type2: Some(data_type) }
+    }
 }
 
 impl fmt::Display for FieldDefinition {

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -18,8 +18,11 @@ pub struct FieldDefinition {
     //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
     //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
     //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
+    //  - sign overpunch: https://support.hpe.com/hpesc/public/docDisplay?docId=c02258569&docLocale=en_US
+    //  - floating types: https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html
 
-    // The total length of the field.
+    // The total character length of the field as specified by the copybook. This may not
+    // match the byte size of comp fields.
     length: u32,
 
     // The data type for the field.

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -18,39 +18,39 @@ pub struct FieldDefinition {
     //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
     //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
     //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
-    data_type: String, //TODO should be an enum
 
-    // FIXME: I'm adding new fields as optional for now to avoid upfront refactoring but this should be fixed before main
-    // The total length of the copybook field
-    length: Option<u32>,
-    data_type2: Option<DataTypeEnum>,
+    // The total length of the field.
+    length: u32,
+
+    // The data type for the field.
+    data_type: DataTypeEnum,
 }
 
 impl FieldDefinition {
-    pub fn new(level: u32, label: String, data_type: String) -> FieldDefinition {
+    pub fn new(
+        level: u32,
+        label: String,
+        length: u32,
+        data_type: DataTypeEnum,
+    ) -> FieldDefinition {
         FieldDefinition {
             level,
             label,
+            length,
             data_type,
-            length: None,
-            data_type2: None,
         }
-    }
-
-    pub fn new_with_length(level: u32, label: String, data_type_str: String,  length: u32, data_type: DataTypeEnum) -> FieldDefinition {
-        FieldDefinition { level, label, data_type: data_type_str, length: Some(length), data_type2: Some(data_type) }
     }
 }
 
 impl fmt::Display for FieldDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        //FIXME: add length and new data type to output
         write!(
             f,
-            "FieldDefinition level={}, label={}, dataType={}",
+            "FieldDefinition level={}, label={}, length={}",
             self.get_level(),
             self.get_label(),
-            self.get_data_type(),
+            self.get_length(),
+            //FIXME: implement display attribute for datatype
         )
     }
 }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -18,7 +18,7 @@ pub struct FieldDefinition {
     // treated as the byte-length of the field, although, in most cases it is the same. There are
     // some binary encoded fields that do not have a character length and others that do not
     // have a one-to-one mapping between character length and byte length where they are not the same.
-    maybe_char_count: Option<u32>,
+    char_count_option: Option<u32>,
 
     // The data type for the field.
     data_type: DataTypeEnum,
@@ -34,7 +34,7 @@ impl FieldDefinition {
         FieldDefinition {
             level,
             label,
-            maybe_char_count,
+            char_count_option: maybe_char_count,
             data_type,
         }
     }
@@ -47,7 +47,7 @@ impl fmt::Display for FieldDefinition {
             "FieldDefinition level={}, label={}, char_count={}, type={}",
             self.get_level(),
             self.get_label(),
-            self.get_maybe_char_count()
+            self.get_char_count_option()
                 .map_or(String::from("null"), |count| count.to_string()),
             self.get_data_type(),
         )

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -12,58 +12,10 @@ pub struct FieldDefinition {
     // The Field's label is defined by the copybook and used to reference the field.
     label: String,
 
-    //TODO NOTES
+    //TODO NOTES - maybe add this to the PR as references
     //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
     //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
     //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
-
-    // Data Type - struct?:
-    //      length - uint32?
-    //
-    //
-    //      
-    //      type_enum - Enum:
-    //          TEXT
-    //          NUMERIC struct
-
-    //              sign - Enum:
-    //                  SIGNED
-    //                  UNSIGNED
-
-    //              comp - Enum
-    //                  NONE
-    //                  COMP-1
-    //                  COMP-2
-    //                  COMP-3
-    //          
-    //          
-    //          DECIMAL_IMPLIED_POINT
-    //          DECIMAL_ASSUMED_POINT_LEFT
-    //          DECIMAL_ASSUMED_POINT_RIGHT
-    //
-    // decimals:
-    //      - digits
-    //      - point position
-    //      - implied decimal point
-    //      - assumed point position
-    //          There are two forms of an assumed decimal point. These are expressed in cobol
-    //          by defining the position value either on the left or right
-    //          LEFT
-    //              P(2)9(3)
-    //                  Is used to represent very small decimal values
-    //                  The P = 2 value means that we are assuming that there are 2 digits
-    //                  to the right of the decimal with the value 0. The 9(3) clause means
-    //                  to keep/track the following 3 digits.
-    //              For Example, we may store the value 0.00345 in this field as 345
-    //          RIGHT
-    //              9(3)P(2)
-    //                  Is used to represent very large integer values
-    //                  The 9(3) clause means to keep/track the first 3 digits of the number while
-    //                  the P = 2 value mans that we are assuming that the last 2 digits in the number
-    //                  are 0.
-    //              For example, we may store the 34500 in this field as 345
-
-    //          there can only be 1 assumed decimal point allowed.
 
     // The total length of the copybook field
     // length: uint32,

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -21,20 +21,31 @@ pub struct FieldDefinition {
     //  - sign overpunch: https://support.hpe.com/hpesc/public/docDisplay?docId=c02258569&docLocale=en_US
     //  - floating types: https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html
 
-    // The total character length of the field as specified by the copybook. This may not
-    // match the byte size of comp fields.
-    length: u32,
+    // The total character length of the field as specified by the copybook. This should not be
+    // treated as the byte-length of the field, although, in most cases it is the same. There are
+    // some binary encoded fields that do not have a character length and others that do not
+    // have a one-to-one mapping between character length and byte length where they are not the same.
+    maybe_char_count: Option<u32>,
 
     // The data type for the field.
     data_type: DataTypeEnum,
 }
 
 impl FieldDefinition {
-    pub fn new(level: u32, label: String, length: u32, data_type: DataTypeEnum) -> FieldDefinition {
+    pub fn new_with_count(level: u32, label: String, char_count: u32, data_type: DataTypeEnum) -> FieldDefinition {
         FieldDefinition {
             level,
             label,
-            length,
+            maybe_char_count: Some(char_count),
+            data_type,
+        }
+    }
+
+    pub fn new(level: u32, label: String, data_type: DataTypeEnum) -> FieldDefinition {
+        FieldDefinition {
+            level,
+            label,
+            maybe_char_count: None,
             data_type,
         }
     }
@@ -44,10 +55,10 @@ impl fmt::Display for FieldDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "FieldDefinition level={}, label={}, length={}",
+            "FieldDefinition level={}, label={}, char_count={}",
             self.get_level(),
             self.get_label(),
-            self.get_length(),
+            self.get_maybe_char_count().map_or(String::from("null"), |count| count.to_string()),
             //FIXME: implement display attribute for datatype
         )
     }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -65,12 +65,12 @@ impl fmt::Display for FieldDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "FieldDefinition level={}, label={}, char_count={}",
+            "FieldDefinition level={}, label={}, char_count={}, type={}",
             self.get_level(),
             self.get_label(),
             self.get_maybe_char_count()
                 .map_or(String::from("null"), |count| count.to_string()),
-            //FIXME: implement display attribute for datatype
+            self.get_data_type(), //FIXME: implement display attribute for datatype
         )
     }
 }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -1,9 +1,11 @@
-use lombok::{AllArgsConstructor, Getter};
+use lombok::Getter;
 use std::fmt;
+
+use super::DataTypeEnum;
 
 /// A FieldDefinition defines a copybook field.
 /// This contains it's level, label, and data type.
-#[derive(AllArgsConstructor, Getter, Debug, Clone, PartialEq)]
+#[derive(Getter, Debug, Clone, PartialEq)]
 pub struct FieldDefinition {
     // Field's defined level in the copybook. This is the number the comes before every field
     // name in the copybook.
@@ -16,20 +18,35 @@ pub struct FieldDefinition {
     //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
     //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
     //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
-
-    // The total length of the copybook field
-    // length: uint32,
     data_type: String, //TODO should be an enum
+
+    // FIXME: I'm adding new fields as optional for now to avoid upfront refactoring but this should be fixed before main
+    // The total length of the copybook field
+    length: Option<u32>,
+    data_type2: Option<DataTypeEnum>,
+}
+
+impl FieldDefinition {
+    pub fn new(level: u32, label: String, data_type: String) -> FieldDefinition {
+        FieldDefinition {
+            level,
+            label,
+            data_type,
+            length: None,
+            data_type2: None,
+        }
+    }
 }
 
 impl fmt::Display for FieldDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        //FIXME: add length and new data type to output
         write!(
             f,
             "FieldDefinition level={}, label={}, dataType={}",
             self.get_level(),
             self.get_label(),
-            self.get_data_type()
+            self.get_data_type(),
         )
     }
 }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -32,7 +32,12 @@ pub struct FieldDefinition {
 }
 
 impl FieldDefinition {
-    pub fn new_with_count(level: u32, label: String, char_count: u32, data_type: DataTypeEnum) -> FieldDefinition {
+    pub fn new_with_count(
+        level: u32,
+        label: String,
+        char_count: u32,
+        data_type: DataTypeEnum,
+    ) -> FieldDefinition {
         FieldDefinition {
             level,
             label,
@@ -41,11 +46,16 @@ impl FieldDefinition {
         }
     }
 
-    pub fn new(level: u32, label: String, data_type: DataTypeEnum) -> FieldDefinition {
+    pub fn new(
+        level: u32,
+        label: String,
+        maybe_char_count: Option<u32>,
+        data_type: DataTypeEnum,
+    ) -> FieldDefinition {
         FieldDefinition {
             level,
             label,
-            maybe_char_count: None,
+            maybe_char_count,
             data_type,
         }
     }
@@ -58,7 +68,8 @@ impl fmt::Display for FieldDefinition {
             "FieldDefinition level={}, label={}, char_count={}",
             self.get_level(),
             self.get_label(),
-            self.get_maybe_char_count().map_or(String::from("null"), |count| count.to_string()),
+            self.get_maybe_char_count()
+                .map_or(String::from("null"), |count| count.to_string()),
             //FIXME: implement display attribute for datatype
         )
     }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -17,14 +17,30 @@ pub struct FieldDefinition {
     //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
     //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
 
-    // modeling:
-    //      There is a type name, binary?, byte size, sign, rust type?
-    //      for decimals there is also scale & precision, decimal point? scale and precision are probably too modern for this layer
-    // 
-    // comp:
-    //      - comp-1
-    //      - comp-2
-    //      - comp-3
+    // Data Type - struct?:
+    //      length - uint32?
+    //
+    //
+    //      
+    //      type_enum - Enum:
+    //          TEXT
+    //          NUMERIC struct
+
+    //              sign - Enum:
+    //                  SIGNED
+    //                  UNSIGNED
+
+    //              comp - Enum
+    //                  NONE
+    //                  COMP-1
+    //                  COMP-2
+    //                  COMP-3
+    //          
+    //          
+    //          DECIMAL_IMPLIED_POINT
+    //          DECIMAL_ASSUMED_POINT_LEFT
+    //          DECIMAL_ASSUMED_POINT_RIGHT
+    //
     // decimals:
     //      - digits
     //      - point position
@@ -49,6 +65,8 @@ pub struct FieldDefinition {
 
     //          there can only be 1 assumed decimal point allowed.
 
+    // The total length of the copybook field
+    // length: uint32,
     data_type: String, //TODO should be an enum
 }
 

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -14,13 +14,6 @@ pub struct FieldDefinition {
     // The Field's label is defined by the copybook and used to reference the field.
     label: String,
 
-    //TODO NOTES - maybe add this to the PR as references
-    //  - cobol data types: https://www.tutorialspoint.com/cobol/cobol_data_types.htm
-    //  - comp clause: https://www.techagilist.com/mainframe/usage-comp-declaration/
-    //  - decimal point: https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm
-    //  - sign overpunch: https://support.hpe.com/hpesc/public/docDisplay?docId=c02258569&docLocale=en_US
-    //  - floating types: https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html
-
     // The total character length of the field as specified by the copybook. This should not be
     // treated as the byte-length of the field, although, in most cases it is the same. There are
     // some binary encoded fields that do not have a character length and others that do not

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -32,20 +32,6 @@ pub struct FieldDefinition {
 }
 
 impl FieldDefinition {
-    pub fn new_with_count(
-        level: u32,
-        label: String,
-        char_count: u32,
-        data_type: DataTypeEnum,
-    ) -> FieldDefinition {
-        FieldDefinition {
-            level,
-            label,
-            maybe_char_count: Some(char_count),
-            data_type,
-        }
-    }
-
     pub fn new(
         level: u32,
         label: String,
@@ -70,7 +56,7 @@ impl fmt::Display for FieldDefinition {
             self.get_label(),
             self.get_maybe_char_count()
                 .map_or(String::from("null"), |count| count.to_string()),
-            self.get_data_type(), //FIXME: implement display attribute for datatype
+            self.get_data_type(),
         )
     }
 }

--- a/rust/copybook-reader/src/copybook/field_definition.rs
+++ b/rust/copybook-reader/src/copybook/field_definition.rs
@@ -27,12 +27,7 @@ pub struct FieldDefinition {
 }
 
 impl FieldDefinition {
-    pub fn new(
-        level: u32,
-        label: String,
-        length: u32,
-        data_type: DataTypeEnum,
-    ) -> FieldDefinition {
+    pub fn new(level: u32, label: String, length: u32, data_type: DataTypeEnum) -> FieldDefinition {
         FieldDefinition {
             level,
             label,

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -84,20 +84,12 @@ impl Clone for GroupDefinition {
 
 impl fmt::Display for GroupDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let _ = writeln!(
-            f,
-            "GroupDefinition level={}, label={}:",
-            self.get_level(),
-            self.get_label()
-        );
-        for statement in self.get_statements() {
-            let _ = writeln!(f, "  {}", statement);
-        }
         write!(
             f,
-            "GroupDefinition End level={} label={}",
+            "GroupDefinition level={}, label={}, statements={}",
             self.get_level(),
-            self.get_label()
+            self.get_label(),
+            self.get_statements().len()
         )
     }
 }

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -113,14 +113,12 @@ mod tests {
         let original = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(
-                FieldDefinition::new_with_count(
-                    2u32,
-                    String::from("ONE"),
-                    5u32,
-                    DataTypeEnum::AlphaNumeric,
-                ),
-            )],
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                2u32,
+                String::from("ONE"),
+                Some(5u32),
+                DataTypeEnum::AlphaNumeric,
+            ))],
         );
 
         assert_eq!(original, original.clone());
@@ -131,30 +129,28 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(
-                FieldDefinition::new_with_count(
-                    2u32,
-                    String::from("ONE"),
-                    5u32,
-                    DataTypeEnum::AlphaNumeric,
-                ),
-            )],
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                2u32,
+                String::from("ONE"),
+                Some(5u32),
+                DataTypeEnum::AlphaNumeric,
+            ))],
         );
 
         let second = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
             vec![
-                StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
+                StatementDefinition::FieldDefinition(FieldDefinition::new(
                     2u32,
                     String::from("ONE"),
-                    5u32,
+                    Some(5u32),
                     DataTypeEnum::AlphaNumeric,
                 )),
-                StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
+                StatementDefinition::FieldDefinition(FieldDefinition::new(
                     2u32,
                     String::from("TWO"),
-                    5u32,
+                    Some(5u32),
                     DataTypeEnum::AlphaNumeric,
                 )),
             ],
@@ -168,27 +164,23 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(
-                FieldDefinition::new_with_count(
-                    2u32,
-                    String::from("ONE"),
-                    5u32,
-                    DataTypeEnum::AlphaNumeric,
-                ),
-            )],
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                2u32,
+                String::from("ONE"),
+                Some(5u32),
+                DataTypeEnum::AlphaNumeric,
+            ))],
         );
 
         let second = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(
-                FieldDefinition::new_with_count(
-                    5u32, // different level
-                    String::from("ONE"),
-                    5u32,
-                    DataTypeEnum::AlphaNumeric,
-                ),
-            )],
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+                5u32, // different level
+                String::from("ONE"),
+                Some(5u32),
+                DataTypeEnum::AlphaNumeric,
+            ))],
         );
 
         assert_ne!(first, second);

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -113,7 +113,7 @@ mod tests {
         let original = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                 2u32,
                 String::from("ONE"),
                 5u32,
@@ -129,7 +129,7 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                 2u32,
                 String::from("ONE"),
                 5u32,
@@ -141,13 +141,13 @@ mod tests {
             1u32,
             String::from("GROUP"),
             vec![
-                StatementDefinition::FieldDefinition(FieldDefinition::new(
+                StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                     2u32,
                     String::from("ONE"),
                     5u32,
                     DataTypeEnum::AlphaNumeric,
                 )),
-                StatementDefinition::FieldDefinition(FieldDefinition::new(
+                StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                     2u32,
                     String::from("TWO"),
                     5u32,
@@ -164,7 +164,7 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                 2u32,
                 String::from("ONE"),
                 5u32,
@@ -175,7 +175,7 @@ mod tests {
         let second = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
+            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
                 5u32, // different level
                 String::from("ONE"),
                 5u32,

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -104,7 +104,7 @@ impl fmt::Display for GroupDefinition {
 
 #[cfg(test)]
 mod tests {
-    use crate::copybook::{FieldDefinition, DataTypeEnum};
+    use crate::copybook::{DataTypeEnum, FieldDefinition};
 
     use super::*;
 

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -91,7 +91,7 @@ impl fmt::Display for GroupDefinition {
             self.get_label()
         );
         for statement in self.get_statements() {
-            let _ = writeln!(f, "{}", statement);
+            let _ = writeln!(f, "  {}", statement);
         }
         write!(
             f,

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -113,12 +113,14 @@ mod tests {
         let original = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
-                2u32,
-                String::from("ONE"),
-                5u32,
-                DataTypeEnum::AlphaNumeric,
-            ))],
+            vec![StatementDefinition::FieldDefinition(
+                FieldDefinition::new_with_count(
+                    2u32,
+                    String::from("ONE"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
+                ),
+            )],
         );
 
         assert_eq!(original, original.clone());
@@ -129,12 +131,14 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
-                2u32,
-                String::from("ONE"),
-                5u32,
-                DataTypeEnum::AlphaNumeric,
-            ))],
+            vec![StatementDefinition::FieldDefinition(
+                FieldDefinition::new_with_count(
+                    2u32,
+                    String::from("ONE"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
+                ),
+            )],
         );
 
         let second = GroupDefinition::create_with_statements(
@@ -164,23 +168,27 @@ mod tests {
         let first = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
-                2u32,
-                String::from("ONE"),
-                5u32,
-                DataTypeEnum::AlphaNumeric,
-            ))],
+            vec![StatementDefinition::FieldDefinition(
+                FieldDefinition::new_with_count(
+                    2u32,
+                    String::from("ONE"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
+                ),
+            )],
         );
 
         let second = GroupDefinition::create_with_statements(
             1u32,
             String::from("GROUP"),
-            vec![StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
-                5u32, // different level
-                String::from("ONE"),
-                5u32,
-                DataTypeEnum::AlphaNumeric,
-            ))],
+            vec![StatementDefinition::FieldDefinition(
+                FieldDefinition::new_with_count(
+                    5u32, // different level
+                    String::from("ONE"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
+                ),
+            )],
         );
 
         assert_ne!(first, second);

--- a/rust/copybook-reader/src/copybook/group_definition.rs
+++ b/rust/copybook-reader/src/copybook/group_definition.rs
@@ -104,7 +104,7 @@ impl fmt::Display for GroupDefinition {
 
 #[cfg(test)]
 mod tests {
-    use crate::copybook::FieldDefinition;
+    use crate::copybook::{FieldDefinition, DataTypeEnum};
 
     use super::*;
 
@@ -116,7 +116,8 @@ mod tests {
             vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
                 2u32,
                 String::from("ONE"),
-                String::from("PIC X(5)"),
+                5u32,
+                DataTypeEnum::AlphaNumeric,
             ))],
         );
 
@@ -131,7 +132,8 @@ mod tests {
             vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
                 2u32,
                 String::from("ONE"),
-                String::from("PIC X(5)"),
+                5u32,
+                DataTypeEnum::AlphaNumeric,
             ))],
         );
 
@@ -142,12 +144,14 @@ mod tests {
                 StatementDefinition::FieldDefinition(FieldDefinition::new(
                     2u32,
                     String::from("ONE"),
-                    String::from("PIC X(5)"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
                 )),
                 StatementDefinition::FieldDefinition(FieldDefinition::new(
                     2u32,
                     String::from("TWO"),
-                    String::from("PIC X(5)"),
+                    5u32,
+                    DataTypeEnum::AlphaNumeric,
                 )),
             ],
         );
@@ -163,7 +167,8 @@ mod tests {
             vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
                 2u32,
                 String::from("ONE"),
-                String::from("PIC X(5)"),
+                5u32,
+                DataTypeEnum::AlphaNumeric,
             ))],
         );
 
@@ -173,7 +178,8 @@ mod tests {
             vec![StatementDefinition::FieldDefinition(FieldDefinition::new(
                 5u32, // different level
                 String::from("ONE"),
-                String::from("PIC X(5)"),
+                5u32,
+                DataTypeEnum::AlphaNumeric,
             ))],
         );
 

--- a/rust/copybook-reader/src/copybook/mod.rs
+++ b/rust/copybook-reader/src/copybook/mod.rs
@@ -6,15 +6,15 @@
 
 // Defines related modules for the copybook module
 pub mod copybook_definition;
+pub mod data_type;
 pub mod field_definition;
 pub mod group_definition;
 pub mod statement_definition;
-pub mod data_type;
 
 // Re-Exports Structs. This provides a flatter Interface for the Copybook module
 // while still allowing us to store this code in separate files.
 pub use self::copybook_definition::CopybookDefinition;
+pub use self::data_type::DataTypeEnum;
 pub use self::field_definition::FieldDefinition;
 pub use self::group_definition::GroupDefinition;
 pub use self::statement_definition::StatementDefinition;
-pub use self::data_type::DataTypeEnum;

--- a/rust/copybook-reader/src/copybook/mod.rs
+++ b/rust/copybook-reader/src/copybook/mod.rs
@@ -9,6 +9,7 @@ pub mod copybook_definition;
 pub mod field_definition;
 pub mod group_definition;
 pub mod statement_definition;
+pub mod data_type;
 
 // Re-Exports Structs. This provides a flatter Interface for the Copybook module
 // while still allowing us to store this code in separate files.
@@ -16,3 +17,4 @@ pub use self::copybook_definition::CopybookDefinition;
 pub use self::field_definition::FieldDefinition;
 pub use self::group_definition::GroupDefinition;
 pub use self::statement_definition::StatementDefinition;
+pub use self::data_type::DataTypeEnum;

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -34,24 +34,41 @@ data_type = {
     )
 }
 
-alphanumeric_type = {
-    "X"
+// This rule is mean to match patterns in the copybook such as "9(2)", "99", or "X(4)" in such a
+// way that if the parenthesis form is used the integer length value can be extracted or if the
+// repeated 9 or X form is used the number of repetitions can be extracted. This rule is not meant
+// to identify whether a 9, X, or V clause is being used that must be matched before this rule
+// without making progress with the & terminal.
+length_literal = {
+    // match the first character and push it onto the stack to be referenced later
+    PUSH(ASCII_ALPHANUMERIC)
     ~ (
-        // Supports alpha-numeric data type format X(100)
-        ("(" ~ integer ~ ")")
-        // Supports alpha-numeric data type format XXXXX
-        | ("X"*)
+        // Matches the parenthesis form which is expected to contain an integer value.
+        (
+            "("
+            ~ integer
+            ~ ")"
+        )
+        // Matches the repeatedSupports the numeric data type format 9999
+        | ( PEEK* )
     )
+    // Since the character is not needed outside of this rule we are going to drop it from the
+    // stack to be safe. Dropped stack characters are not required to be matched.
+    ~ DROP
 }
 
 numeric_type = {
-    "9"
-    ~ (
-        // Supports the numeric data type format 9(100)
-        ("(" ~ integer ~ ")")
-        // Supports the numeric data type format 9999
-        | ( "9"* )
-    )
+    // Numeric types always start with 9 but since the length_literal rule needs the
+    // 9 to operate correctly we are not going to consume the character.
+    &"9"
+    ~ length_literal
+}
+
+alphanumeric_type = {
+    // alphanumeric types always start with X but since the length_literal rule needs the
+    // X to operate correctly we are not going to consume the character.
+    &"X"
+    ~ length_literal
 }
 
 field = {

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -29,7 +29,9 @@ data_type = {
     picture
     ~ whitespace+
     ~ (
-        alphanumeric_type
+        alphabetic_type
+        | decimal_type
+        | alphanumeric_type
         | numeric_type
     )
 }
@@ -57,10 +59,10 @@ length_literal = {
     ~ DROP
 }
 
-numeric_type = {
-    // Numeric types always start with 9 but since the length_literal rule needs the
-    // 9 to operate correctly we are not going to consume the character.
-    &"9"
+alphabetic_type = {
+    // alphanumeric types always start with A but since the length_literal rule needs the
+    // A to operate correctly we are not going to consume the character.
+    &"A"
     ~ length_literal
 }
 
@@ -68,6 +70,48 @@ alphanumeric_type = {
     // alphanumeric types always start with X but since the length_literal rule needs the
     // X to operate correctly we are not going to consume the character.
     &"X"
+    ~ length_literal
+}
+
+numeric_type = {
+    // Numeric types always start with 9 but since the length_literal rule needs the
+    // 9 to operate correctly we are not going to consume the character.
+    &"9"
+    ~ length_literal
+}
+
+decimal_type = {
+    // implied decimal point formats
+    implied_decimal_point
+    | assumed_decimal_point_left
+    | assumed_decimal_point_right
+}
+
+// Implied Decimal points indicate the exact position of the decimal with either a
+// "V" or a ".". So these typically look like 9(2)V(3) or 9(3).(2)
+implied_decimal_point = {
+    &"9"
+    ~ length_literal
+    ~ ("V" | ".")
+    ~ &"9"
+    ~ length_literal
+}
+
+// Assumed decimal point left always has a position length literal on the left such as
+// P(2)9(3) or PP9(3).
+assumed_decimal_point_left = {
+    &"P"
+    ~ length_literal
+    ~ &"9"
+    ~ length_literal
+}
+
+// Assumed decimal point right always has a position length literal on the right such as
+// 9(3)P(2) or 9(3)PP.
+assumed_decimal_point_right = {
+    &"9"
+    ~ length_literal
+    ~ &"P"
     ~ length_literal
 }
 

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -60,7 +60,7 @@ data_type = {
     )
 }
 
-// This rule is mean to match patterns in the copybook such as "9(2)", "99", or "X(4)" in such a
+// This rule is meant to match patterns in the copybook such as "9(2)", "99", or "X(4)" in such a
 // way that if the parenthesis form is used the integer length value can be extracted or if the
 // repeated 9 or X form is used the number of repetitions can be extracted. This rule is not meant
 // to identify whether a 9, X, or V clause is being used that must be matched before this rule
@@ -75,7 +75,7 @@ length_literal = {
             ~ integer
             ~ ")"
         )
-        // Matches the repeatedSupports the numeric data type format 9999
+        // Matches the repeated form such as 9999
         | ( PEEK* )
     )
     // Since the character is not needed outside of this rule we are going to drop it from the

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -7,6 +7,14 @@ picture = _{
     "PIC"
 }
 
+signed = {
+    "S" | "s"
+}
+
+precision = {
+    "P" | "p"
+}
+
 comp = {
     "COMP"
 }
@@ -78,14 +86,14 @@ length_literal = {
 alphabetic_type = {
     // alphanumeric types always start with A but since the length_literal rule needs the
     // A to operate correctly we are not going to consume the character.
-    &"A"
+    & ("A" | "a")
     ~ length_literal
 }
 
 alphanumeric_type = {
     // alphanumeric types always start with X but since the length_literal rule needs the
     // X to operate correctly we are not going to consume the character.
-    &"X"
+    & ("X" | "x")
     ~ length_literal
 }
 
@@ -127,7 +135,7 @@ comp3_type = {
 implied_decimal_point = {
     &"9"
     ~ length_literal
-    ~ ("V" | ".")
+    ~ ("V" | "v" | ".")
     ~ &"9"
     ~ length_literal
 }
@@ -135,7 +143,7 @@ implied_decimal_point = {
 // Assumed decimal point left always has a position length literal on the left such as
 // P(2)9(3) or PP9(3).
 assumed_decimal_point_left = {
-    &"P"
+    & precision
     ~ length_literal
     ~ &"9"
     ~ length_literal
@@ -146,12 +154,8 @@ assumed_decimal_point_left = {
 assumed_decimal_point_right = {
     &"9"
     ~ length_literal
-    ~ &"P"
+    ~ & precision
     ~ length_literal
-}
-
-signed = {
-    "S"
 }
 
 field = {

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -1,7 +1,18 @@
 whitespace = _{ " " }
 
+picture = _{
+    // In Cobol Picture clauses are used to define the attributes of the data type.
+    // This is a silent rule because although it identifies a data type clause it does
+    // not provide actual value to the CopybookDefinition structure.
+    "PIC"
+}
+
 level = { 
     ASCII_DIGIT+ 
+}
+
+integer = {
+    ASCII_DIGIT+
 }
 
 label = {
@@ -15,7 +26,32 @@ label = {
 }
 
 data_type = {
-    "PIC " ~ ASCII_ALPHANUMERIC+ ~ "(" ~ ASCII_DIGIT ~ ")"
+    picture
+    ~ whitespace+
+    ~ (
+        alphanumeric_type
+        | numeric_type
+    )
+}
+
+alphanumeric_type = {
+    "X"
+    ~ (
+        // Supports alpha-numeric data type format X(100)
+        "(" ~ integer ~ ")"
+        // Supports alpha-numeric data type format XXXXX
+        | ("X"*)
+    )
+}
+
+numeric_type = {
+    "9"
+    ~ (
+        // Supports the numeric data type format 9(100)
+        ("(" ~ ASCII_DIGIT+ ~ ")")
+        // Supports the numeric data type format 9999
+        | ( "9"* )
+    )
 }
 
 field = {

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -11,6 +11,14 @@ comp = {
     "COMP"
 }
 
+comp1_type = {
+    "COMP-1"
+}
+
+comp2_type = {
+    "COMP-2"
+}
+
 level = { 
     ASCII_DIGIT+ 
 }
@@ -30,12 +38,17 @@ label = {
 }
 
 data_type = {
-    picture
-    ~ whitespace+
-    ~ (
-        numeric_type
-        | alphabetic_type
-        | alphanumeric_type
+    comp1_type
+    | comp2_type
+    | (
+        picture
+        ~ whitespace+
+        ~ (
+            comp3_type
+            | numeric_type
+            | alphabetic_type
+            | alphanumeric_type
+        )
     )
 }
 
@@ -98,6 +111,15 @@ number_type = {
     // 9 to operate correctly we are not going to consume the character.
     &"9"
     ~ length_literal
+}
+
+comp3_type = {
+    // The COMP-3 type is a special type of binary number type so it looks similar to the number
+    // type but does not have as much flexibility as the rest of the numeric types
+    &"9"
+    ~ length_literal
+    ~ whitespace+
+    ~ "COMP-3"
 }
 
 // Implied Decimal points indicate the exact position of the decimal with either a

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -7,6 +7,10 @@ picture = _{
     "PIC"
 }
 
+comp = {
+    "COMP"
+}
+
 level = { 
     ASCII_DIGIT+ 
 }
@@ -29,10 +33,9 @@ data_type = {
     picture
     ~ whitespace+
     ~ (
-        alphabetic_type
-        | decimal_type
+        numeric_type
+        | alphabetic_type
         | alphanumeric_type
-        | numeric_type
     )
 }
 
@@ -74,23 +77,27 @@ alphanumeric_type = {
 }
 
 numeric_type = {
-    // numeric types can be signed by providing a S prefix, by default numeric types are unsigned.
     signed?
-    // Numeric types are identified with a 9 but since the length_literal rule needs the
-    // 9 to operate correctly we are not going to consume the character.
-    ~ &"9"
-    ~ length_literal
-}
 
-decimal_type = {
-    // decimal types can be signed by providing a S prefix, by default decimal types are unsigned.
-    signed?
-    // the decimal must match one of the formats below
     ~ (
         implied_decimal_point
         | assumed_decimal_point_left
         | assumed_decimal_point_right
+        | number_type
     )
+
+    // The COMP clause can optionally be provided on a numeric type
+    ~ (
+        whitespace+
+        ~ comp
+    )?
+}
+
+number_type = {
+    // Numeric types are identified with a 9 but since the length_literal rule needs the
+    // 9 to operate correctly we are not going to consume the character.
+    &"9"
+    ~ length_literal
 }
 
 // Implied Decimal points indicate the exact position of the decimal with either a

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -74,17 +74,23 @@ alphanumeric_type = {
 }
 
 numeric_type = {
-    // Numeric types always start with 9 but since the length_literal rule needs the
+    // numeric types can be signed by providing a S prefix, by default numeric types are unsigned.
+    signed?
+    // Numeric types are identified with a 9 but since the length_literal rule needs the
     // 9 to operate correctly we are not going to consume the character.
-    &"9"
+    ~ &"9"
     ~ length_literal
 }
 
 decimal_type = {
-    // implied decimal point formats
-    implied_decimal_point
-    | assumed_decimal_point_left
-    | assumed_decimal_point_right
+    // decimal types can be signed by providing a S prefix, by default decimal types are unsigned.
+    signed?
+    // the decimal must match one of the formats below
+    ~ (
+        implied_decimal_point
+        | assumed_decimal_point_left
+        | assumed_decimal_point_right
+    )
 }
 
 // Implied Decimal points indicate the exact position of the decimal with either a
@@ -113,6 +119,10 @@ assumed_decimal_point_right = {
     ~ length_literal
     ~ &"P"
     ~ length_literal
+}
+
+signed = {
+    "S"
 }
 
 field = {

--- a/rust/copybook-reader/src/copybook_grammar.pest
+++ b/rust/copybook-reader/src/copybook_grammar.pest
@@ -38,7 +38,7 @@ alphanumeric_type = {
     "X"
     ~ (
         // Supports alpha-numeric data type format X(100)
-        "(" ~ integer ~ ")"
+        ("(" ~ integer ~ ")")
         // Supports alpha-numeric data type format XXXXX
         | ("X"*)
     )
@@ -48,7 +48,7 @@ numeric_type = {
     "9"
     ~ (
         // Supports the numeric data type format 9(100)
-        ("(" ~ ASCII_DIGIT+ ~ ")")
+        ("(" ~ integer ~ ")")
         // Supports the numeric data type format 9999
         | ( "9"* )
     )

--- a/rust/copybook-reader/src/lib.rs
+++ b/rust/copybook-reader/src/lib.rs
@@ -289,6 +289,7 @@ mod tests {
                     copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new(
                         1u32,
                         String::from("FIELDNAME"),
+                        //TODO it's time to refactor this out
                         String::from("PIC X(5)"),
                     )),
                 ]);

--- a/rust/copybook-reader/src/lib.rs
+++ b/rust/copybook-reader/src/lib.rs
@@ -290,12 +290,14 @@ mod tests {
         match parse_result {
             Ok(copybook_definition) => {
                 let expected_copybook = copybook::CopybookDefinition::create_with_statements(vec![
-                    copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new_with_count(
-                        1u32,
-                        String::from("FIELDNAME"),
-                        5u32,
-                        DataTypeEnum::AlphaNumeric,
-                    )),
+                    copybook::StatementDefinition::FieldDefinition(
+                        copybook::FieldDefinition::new_with_count(
+                            1u32,
+                            String::from("FIELDNAME"),
+                            5u32,
+                            DataTypeEnum::AlphaNumeric,
+                        ),
+                    ),
                 ]);
                 assert_eq!(copybook_definition, expected_copybook);
             }

--- a/rust/copybook-reader/src/lib.rs
+++ b/rust/copybook-reader/src/lib.rs
@@ -71,16 +71,16 @@ mod rule_parser;
 ///         1u32,
 ///         String::from("RECORD"),
 ///         vec![
-///             StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
+///             StatementDefinition::FieldDefinition(FieldDefinition::new(
 ///                 2u32,
 ///                 String::from("FIRST-FIELD"),
-///                 5u32,
+///                 Some(5u32),
 ///                 DataTypeEnum::AlphaNumeric,
 ///             )),
-///             StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
+///             StatementDefinition::FieldDefinition(FieldDefinition::new(
 ///                 2u32,
 ///                 String::from("SECOND-FIELD"),
-///                 5u32,
+///                 Some(5u32),
 ///                 DataTypeEnum::AlphaNumeric,
 ///             )),
 ///         ],
@@ -290,14 +290,12 @@ mod tests {
         match parse_result {
             Ok(copybook_definition) => {
                 let expected_copybook = copybook::CopybookDefinition::create_with_statements(vec![
-                    copybook::StatementDefinition::FieldDefinition(
-                        copybook::FieldDefinition::new_with_count(
-                            1u32,
-                            String::from("FIELDNAME"),
-                            5u32,
-                            DataTypeEnum::AlphaNumeric,
-                        ),
-                    ),
+                    copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new(
+                        1u32,
+                        String::from("FIELDNAME"),
+                        Some(5u32),
+                        DataTypeEnum::AlphaNumeric,
+                    )),
                 ]);
                 assert_eq!(copybook_definition, expected_copybook);
             }
@@ -324,18 +322,18 @@ mod tests {
                             String::from("GROUPNAME"),
                             vec![
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new_with_count(
+                                    copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FIRSTFIELD"),
-                                        5u32,
+                                        Some(5u32),
                                         DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new_with_count(
+                                    copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("SECONDFIELD"),
-                                        5u32,
+                                        Some(5u32),
                                         DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
@@ -374,18 +372,18 @@ mod tests {
                             String::from("GROUPONE"),
                             vec![
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new_with_count(
+                                    copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FIRSTFIELD"),
-                                        5u32,
+                                        Some(5u32),
                                         DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new_with_count(
+                                    copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("SECONDFIELD"),
-                                        5u32,
+                                        Some(5u32),
                                         DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
@@ -394,20 +392,20 @@ mod tests {
                                         5u32,
                                         String::from("GROUPTWO"),
                                         vec![copybook::StatementDefinition::FieldDefinition(
-                                            copybook::FieldDefinition::new_with_count(
+                                            copybook::FieldDefinition::new(
                                                 10u32,
                                                 String::from("THIRDFIELD"),
-                                                1u32,
+                                                Some(1u32),
                                                 DataTypeEnum::AlphaNumeric,
                                             ),
                                         )],
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new_with_count(
+                                    copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FOURTHFIELD"),
-                                        1u32,
+                                        Some(1u32),
                                         DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
@@ -419,10 +417,10 @@ mod tests {
                             1u32,
                             String::from("GROUPTHREE"),
                             vec![copybook::StatementDefinition::FieldDefinition(
-                                copybook::FieldDefinition::new_with_count(
+                                copybook::FieldDefinition::new(
                                     5u32,
                                     String::from("FIFTHFIELD"),
-                                    9u32,
+                                    Some(9u32),
                                     DataTypeEnum::AlphaNumeric,
                                 ),
                             )],
@@ -510,10 +508,10 @@ mod tests {
                             1u32,
                             String::from("GROUPONE"),
                             vec![copybook::StatementDefinition::FieldDefinition(
-                                copybook::FieldDefinition::new_with_count(
+                                copybook::FieldDefinition::new(
                                     5u32,
                                     String::from("FIRSTFIELD"),
-                                    5u32,
+                                    Some(5u32),
                                     DataTypeEnum::AlphaNumeric,
                                 ),
                             )],

--- a/rust/copybook-reader/src/lib.rs
+++ b/rust/copybook-reader/src/lib.rs
@@ -71,13 +71,13 @@ mod rule_parser;
 ///         1u32,
 ///         String::from("RECORD"),
 ///         vec![
-///             StatementDefinition::FieldDefinition(FieldDefinition::new(
+///             StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
 ///                 2u32,
 ///                 String::from("FIRST-FIELD"),
 ///                 5u32,
 ///                 DataTypeEnum::AlphaNumeric,
 ///             )),
-///             StatementDefinition::FieldDefinition(FieldDefinition::new(
+///             StatementDefinition::FieldDefinition(FieldDefinition::new_with_count(
 ///                 2u32,
 ///                 String::from("SECOND-FIELD"),
 ///                 5u32,
@@ -290,7 +290,7 @@ mod tests {
         match parse_result {
             Ok(copybook_definition) => {
                 let expected_copybook = copybook::CopybookDefinition::create_with_statements(vec![
-                    copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new(
+                    copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new_with_count(
                         1u32,
                         String::from("FIELDNAME"),
                         5u32,
@@ -322,7 +322,7 @@ mod tests {
                             String::from("GROUPNAME"),
                             vec![
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new(
+                                    copybook::FieldDefinition::new_with_count(
                                         5u32,
                                         String::from("FIRSTFIELD"),
                                         5u32,
@@ -330,7 +330,7 @@ mod tests {
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new(
+                                    copybook::FieldDefinition::new_with_count(
                                         5u32,
                                         String::from("SECONDFIELD"),
                                         5u32,
@@ -372,7 +372,7 @@ mod tests {
                             String::from("GROUPONE"),
                             vec![
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new(
+                                    copybook::FieldDefinition::new_with_count(
                                         5u32,
                                         String::from("FIRSTFIELD"),
                                         5u32,
@@ -380,7 +380,7 @@ mod tests {
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new(
+                                    copybook::FieldDefinition::new_with_count(
                                         5u32,
                                         String::from("SECONDFIELD"),
                                         5u32,
@@ -392,7 +392,7 @@ mod tests {
                                         5u32,
                                         String::from("GROUPTWO"),
                                         vec![copybook::StatementDefinition::FieldDefinition(
-                                            copybook::FieldDefinition::new(
+                                            copybook::FieldDefinition::new_with_count(
                                                 10u32,
                                                 String::from("THIRDFIELD"),
                                                 1u32,
@@ -402,7 +402,7 @@ mod tests {
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
-                                    copybook::FieldDefinition::new(
+                                    copybook::FieldDefinition::new_with_count(
                                         5u32,
                                         String::from("FOURTHFIELD"),
                                         1u32,
@@ -417,7 +417,7 @@ mod tests {
                             1u32,
                             String::from("GROUPTHREE"),
                             vec![copybook::StatementDefinition::FieldDefinition(
-                                copybook::FieldDefinition::new(
+                                copybook::FieldDefinition::new_with_count(
                                     5u32,
                                     String::from("FIFTHFIELD"),
                                     9u32,
@@ -508,7 +508,7 @@ mod tests {
                             1u32,
                             String::from("GROUPONE"),
                             vec![copybook::StatementDefinition::FieldDefinition(
-                                copybook::FieldDefinition::new(
+                                copybook::FieldDefinition::new_with_count(
                                     5u32,
                                     String::from("FIRSTFIELD"),
                                     5u32,

--- a/rust/copybook-reader/src/lib.rs
+++ b/rust/copybook-reader/src/lib.rs
@@ -74,12 +74,14 @@ mod rule_parser;
 ///             StatementDefinition::FieldDefinition(FieldDefinition::new(
 ///                 2u32,
 ///                 String::from("FIRST-FIELD"),
-///                 String::from("PIC X(5)"),
+///                 5u32,
+///                 DataTypeEnum::AlphaNumeric,
 ///             )),
 ///             StatementDefinition::FieldDefinition(FieldDefinition::new(
 ///                 2u32,
 ///                 String::from("SECOND-FIELD"),
-///                 String::from("PIC X(5)"),
+///                 5u32,
+///                 DataTypeEnum::AlphaNumeric,
 ///             )),
 ///         ],
 ///     )),
@@ -275,6 +277,8 @@ fn place_new_group(
 
 #[cfg(test)]
 mod tests {
+    use crate::copybook::DataTypeEnum;
+
     use super::*;
 
     use test_log::test;
@@ -289,8 +293,8 @@ mod tests {
                     copybook::StatementDefinition::FieldDefinition(copybook::FieldDefinition::new(
                         1u32,
                         String::from("FIELDNAME"),
-                        //TODO it's time to refactor this out
-                        String::from("PIC X(5)"),
+                        5u32,
+                        DataTypeEnum::AlphaNumeric,
                     )),
                 ]);
                 assert_eq!(copybook_definition, expected_copybook);
@@ -321,14 +325,16 @@ mod tests {
                                     copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FIRSTFIELD"),
-                                        String::from("PIC X(5)"),
+                                        5u32,
+                                        DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
                                     copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("SECONDFIELD"),
-                                        String::from("PIC X(5)"),
+                                        5u32,
+                                        DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                             ],
@@ -369,14 +375,16 @@ mod tests {
                                     copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FIRSTFIELD"),
-                                        String::from("PIC X(5)"),
+                                        5u32,
+                                        DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                                 copybook::StatementDefinition::FieldDefinition(
                                     copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("SECONDFIELD"),
-                                        String::from("PIC X(5)"),
+                                        5u32,
+                                        DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                                 copybook::StatementDefinition::GroupDefinition(
@@ -387,7 +395,8 @@ mod tests {
                                             copybook::FieldDefinition::new(
                                                 10u32,
                                                 String::from("THIRDFIELD"),
-                                                String::from("PIC X(1)"),
+                                                1u32,
+                                                DataTypeEnum::AlphaNumeric,
                                             ),
                                         )],
                                     ),
@@ -396,7 +405,8 @@ mod tests {
                                     copybook::FieldDefinition::new(
                                         5u32,
                                         String::from("FOURTHFIELD"),
-                                        String::from("PIC X(1)"),
+                                        1u32,
+                                        DataTypeEnum::AlphaNumeric,
                                     ),
                                 ),
                             ],
@@ -410,7 +420,8 @@ mod tests {
                                 copybook::FieldDefinition::new(
                                     5u32,
                                     String::from("FIFTHFIELD"),
-                                    String::from("PIC X(9)"),
+                                    9u32,
+                                    DataTypeEnum::AlphaNumeric,
                                 ),
                             )],
                         ),
@@ -500,7 +511,8 @@ mod tests {
                                 copybook::FieldDefinition::new(
                                     5u32,
                                     String::from("FIRSTFIELD"),
-                                    String::from("PIC X(5)"),
+                                    5u32,
+                                    DataTypeEnum::AlphaNumeric,
                                 ),
                             )],
                         ),

--- a/rust/copybook-reader/src/parse_errors.rs
+++ b/rust/copybook-reader/src/parse_errors.rs
@@ -1,4 +1,4 @@
-use crate::{rule_parser::map_rule_to_name, Rule};
+use crate::Rule;
 use pest::error::Error;
 use std::fmt;
 
@@ -58,8 +58,8 @@ impl CopybookParseError {
                 negatives: _,
             } => positives
                 .iter()
-                .map(map_rule_to_name)
-                .collect::<Vec<&str>>()
+                .map(Rule::to_string)
+                .collect::<Vec<String>>()
                 .join(","),
             pest::error::ErrorVariant::CustomError { message } => message.to_string(),
         };

--- a/rust/copybook-reader/src/rule_parser.rs
+++ b/rust/copybook-reader/src/rule_parser.rs
@@ -21,12 +21,7 @@ fn field_rule_into_definition(field_rule: Pair<Rule>, level: u32) -> copybook::F
     let data_type_rule = inner_field_rules.next().unwrap();
     let length_and_data_type = data_type_rule_into_length_and_type(data_type_rule);
 
-    copybook::FieldDefinition::new_with_count(
-        level,
-        label,
-        length_and_data_type.0,
-        length_and_data_type.1,
-    )
+    copybook::FieldDefinition::new(level, label, length_and_data_type.0, length_and_data_type.1)
 }
 
 fn length_literal_rule_into_u32(length_literal_pair: Pair<Rule>) -> u32 {
@@ -54,7 +49,7 @@ fn length_literal_rule_into_u32(length_literal_pair: Pair<Rule>) -> u32 {
     }
 }
 
-fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, DataTypeEnum) {
+fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u32>, DataTypeEnum) {
     // The data_type rule should always contain 1 inner rule that identifies the actual type
     // and carries extra information about that specific data type in subtype
     let subtype_pair = data_type_pair.into_inner().next().unwrap();
@@ -68,7 +63,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
             let length_literal_pair = subtype_inner.next().unwrap();
             let length = length_literal_rule_into_u32(length_literal_pair);
 
-            (length, DataTypeEnum::Alphabetic)
+            (Some(length), DataTypeEnum::Alphabetic)
         }
         Rule::alphanumeric_type => {
             let mut subtype_inner = subtype_pair.into_inner();
@@ -76,7 +71,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
             let length_literal_pair = subtype_inner.next().unwrap();
             let length = length_literal_rule_into_u32(length_literal_pair);
 
-            (length, DataTypeEnum::AlphaNumeric)
+            (Some(length), DataTypeEnum::AlphaNumeric)
         }
         Rule::numeric_type => {
             let is_simple_binary = inner_data_type_rule_has_comp(subtype_pair.clone());
@@ -89,13 +84,13 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
                 Rule::number_type => {
                     let length_literal_pair = decimal_or_number_pair.into_inner().next().unwrap();
                     let length = length_literal_rule_into_u32(length_literal_pair);
-                    (
-                        length,
+                    return (
+                        Some(length),
                         DataTypeEnum::Number(copybook::data_type::Number::new(
                             sign_enum,
                             is_simple_binary,
                         )),
-                    )
+                    );
                 }
                 Rule::implied_decimal_point => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -105,15 +100,15 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    (
-                        left + right,
+                    return (
+                        Some(left + right),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
                             DecimalTypeEnum::ImpliedPoint,
                             left,
                             is_simple_binary,
                         )),
-                    )
+                    );
                 }
                 Rule::assumed_decimal_point_left => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -123,15 +118,15 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    (
-                        right,
+                    return (
+                        Some(right),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
                             DecimalTypeEnum::AssumedPointLeft,
                             left,
                             is_simple_binary,
                         )),
-                    )
+                    );
                 }
                 Rule::assumed_decimal_point_right => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -141,18 +136,25 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (u32, Data
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    (
-                        left,
+                    return (
+                        Some(left),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
                             DecimalTypeEnum::AssumedPointRight,
                             right,
                             is_simple_binary,
                         )),
-                    )
+                    );
                 }
                 _ => unreachable!("Undefined numeric type in rule parser"),
             }
+        }
+        Rule::comp1_type => (None, DataTypeEnum::Comp1),
+        Rule::comp2_type => (None, DataTypeEnum::Comp2),
+        Rule::comp3_type => {
+            let length_literal_pair = subtype_pair.into_inner().next().unwrap();
+            let length = length_literal_rule_into_u32(length_literal_pair);
+            (Some(length), DataTypeEnum::Comp3)
         }
         _ => unreachable!("Undefined data type rule in rule parser"),
     }
@@ -236,6 +238,9 @@ pub fn map_rule_to_name(rule: &Rule) -> &'static str {
         Rule::assumed_decimal_point_left => "assumed_decimal_point_left",
         Rule::assumed_decimal_point_right => "assumed_decimal_point_right",
         Rule::comp => "comp",
+        Rule::comp1_type => "comp1_type",
+        Rule::comp2_type => "comp2_type",
+        Rule::comp3_type => "comp3_type",
         Rule::signed => "signed",
         Rule::field => "field",
         Rule::group => "group",
@@ -301,7 +306,8 @@ mod tests {
         "PIC 9(3)V9(2)",
         "PIC 9(1).9(5)",
         "PIC P(3)9(2)",
-        "PIC 9(2)P(3)"
+        "PIC 9(2)P(3)",
+        "PIC 9(7) COMP-3",
     }, expected_length = {
         2u32,
         3u32,
@@ -314,7 +320,8 @@ mod tests {
         5u32,
         6u32,
         2u32,
-        2u32
+        2u32,
+        7u32,
     })]
     fn should_parse_lengths(copybook_str: &str, expected_length: u32) {
         let result = CopybookPestParser::parse(Rule::data_type, copybook_str);
@@ -322,7 +329,7 @@ mod tests {
 
         let data_type_pair = result.unwrap().next().unwrap();
         let length_and_type = data_type_rule_into_length_and_type(data_type_pair);
-        assert_eq!(length_and_type.0, expected_length);
+        assert_eq!(length_and_type.0.unwrap(), expected_length);
     }
 
     #[parameterized(copybook_str = {
@@ -363,6 +370,24 @@ mod tests {
         DataTypeEnum::Decimal(Decimal::new(SignEnum::UNSIGNED,  DecimalTypeEnum::AssumedPointRight, 3u32, true)),
     })]
     fn should_parse_decimal_types(copybook_str: &str, expected_type: DataTypeEnum) {
+        let result = CopybookPestParser::parse(Rule::data_type, copybook_str);
+        assert!(result.is_ok());
+
+        let data_type_pair = result.unwrap().next().unwrap();
+        let length_and_type = data_type_rule_into_length_and_type(data_type_pair);
+        assert_eq!(length_and_type.1, expected_type);
+    }
+
+    #[parameterized(copybook_str = {
+        "COMP-1",
+        "COMP-2",
+        "PIC 9(3) COMP-3",
+    }, expected_type = {
+        DataTypeEnum::Comp1,
+        DataTypeEnum::Comp2,
+        DataTypeEnum::Comp3,
+    })]
+    fn should_parse_comp_types(copybook_str: &str, expected_type: DataTypeEnum) {
         let result = CopybookPestParser::parse(Rule::data_type, copybook_str);
         assert!(result.is_ok());
 

--- a/rust/copybook-reader/src/rule_parser.rs
+++ b/rust/copybook-reader/src/rule_parser.rs
@@ -53,9 +53,6 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
     // The data_type rule should always contain 1 inner rule that identifies the actual type
     // and carries extra information about that specific data type in subtype
     let subtype_pair = data_type_pair.into_inner().next().unwrap();
-    let subtype_span = subtype_pair.as_span();
-    println!("subtype pair: {:?}", subtype_pair);
-    println!("subtype span: {:?}", subtype_span);
     match subtype_pair.as_rule() {
         Rule::alphabetic_type => {
             let mut subtype_inner = subtype_pair.into_inner();
@@ -237,6 +234,7 @@ pub fn map_rule_to_name(rule: &Rule) -> &'static str {
         Rule::implied_decimal_point => "implied_decimal_point",
         Rule::assumed_decimal_point_left => "assumed_decimal_point_left",
         Rule::assumed_decimal_point_right => "assumed_decimal_point_right",
+        Rule::precision => "precision",
         Rule::comp => "comp",
         Rule::comp1_type => "comp1_type",
         Rule::comp2_type => "comp2_type",

--- a/rust/copybook-reader/src/rule_parser.rs
+++ b/rust/copybook-reader/src/rule_parser.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use pest::error::Error;
 use pest::iterators::Pair;
 use pest::iterators::Pairs;
@@ -217,33 +219,12 @@ pub fn string_into_file_rule(copybook_str: &str) -> Result<Pairs<Rule>, Box<Erro
     }
 }
 
-pub fn map_rule_to_name(rule: &Rule) -> &'static str {
-    match rule {
-        Rule::EOI => "EOI",
-        Rule::whitespace => "whitespace",
-        Rule::picture => "picture",
-        Rule::level => "level",
-        Rule::label => "label",
-        Rule::data_type => "data_type",
-        Rule::integer => "integer",
-        Rule::length_literal => "length_literal",
-        Rule::alphabetic_type => "alphabetic_type",
-        Rule::alphanumeric_type => "alphanumeric_type",
-        Rule::numeric_type => "numeric_type",
-        Rule::number_type => "number_type",
-        Rule::implied_decimal_point => "implied_decimal_point",
-        Rule::assumed_decimal_point_left => "assumed_decimal_point_left",
-        Rule::assumed_decimal_point_right => "assumed_decimal_point_right",
-        Rule::precision => "precision",
-        Rule::comp => "comp",
-        Rule::comp1_type => "comp1_type",
-        Rule::comp2_type => "comp2_type",
-        Rule::comp3_type => "comp3_type",
-        Rule::signed => "signed",
-        Rule::field => "field",
-        Rule::group => "group",
-        Rule::statement => "statement",
-        Rule::file => "file",
+impl fmt::Display for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // The debug trait for an enum will display a lot of extra info than the display trait
+        // needs when an enum variant is a struct. So to avoid that we are extracting only the
+        // enum variant name which comes before the first "(".
+        write!(f, "{}", format!("{:?}", self).split('(').next().unwrap())
     }
 }
 
@@ -445,5 +426,10 @@ mod tests {
             Ok(_) => unreachable!("this string should always be invalid"),
             Err(_) => assert!(true),
         }
+    }
+
+    #[test]
+    fn map_rule_to_name_should_match_variant_name() {
+        assert_eq!(Rule::data_type.to_string(), "data_type");
     }
 }

--- a/rust/copybook-reader/src/rule_parser.rs
+++ b/rust/copybook-reader/src/rule_parser.rs
@@ -84,13 +84,13 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                 Rule::number_type => {
                     let length_literal_pair = decimal_or_number_pair.into_inner().next().unwrap();
                     let length = length_literal_rule_into_u32(length_literal_pair);
-                    return (
+                    (
                         Some(length),
                         DataTypeEnum::Number(copybook::data_type::Number::new(
                             sign_enum,
                             is_simple_binary,
                         )),
-                    );
+                    )
                 }
                 Rule::implied_decimal_point => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -100,7 +100,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    return (
+                    (
                         Some(left + right),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
@@ -108,7 +108,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                             left,
                             is_simple_binary,
                         )),
-                    );
+                    )
                 }
                 Rule::assumed_decimal_point_left => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -118,7 +118,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    return (
+                    (
                         Some(right),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
@@ -126,7 +126,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                             left,
                             is_simple_binary,
                         )),
-                    );
+                    )
                 }
                 Rule::assumed_decimal_point_right => {
                     let mut decimal_point_type_inner = decimal_or_number_pair.into_inner();
@@ -136,7 +136,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                     let right =
                         length_literal_rule_into_u32(decimal_point_type_inner.next().unwrap());
 
-                    return (
+                    (
                         Some(left),
                         DataTypeEnum::Decimal(Decimal::new(
                             sign_enum,
@@ -144,7 +144,7 @@ fn data_type_rule_into_length_and_type(data_type_pair: Pair<Rule>) -> (Option<u3
                             right,
                             is_simple_binary,
                         )),
-                    );
+                    )
                 }
                 _ => unreachable!("Undefined numeric type in rule parser"),
             }
@@ -167,9 +167,9 @@ fn inner_data_type_rule_into_sign_enum(pair_inner_iter: &mut Pairs<Rule>) -> Sig
         Some(first_pair) => {
             if first_pair.as_rule() == Rule::signed {
                 pair_inner_iter.next();
-                return SignEnum::SIGNED;
+                SignEnum::SIGNED
             } else {
-                return SignEnum::UNSIGNED;
+                SignEnum::UNSIGNED
             }
         }
         None => SignEnum::UNSIGNED,

--- a/rust/copybook-reader/tests/integration_test.rs
+++ b/rust/copybook-reader/tests/integration_test.rs
@@ -14,8 +14,8 @@ fn get_copybook_directory() -> String {
 #[parameterized(filename = {
     "one_group_field.cpy",
     "one_field.cpy",
+    "types.cpy",
     // FIXME: These copybooks are not yet supported
-    // "types.cpy",
     // "complex.cpy",
     // "line_numbers.cpy",
     // "program.cbl"

--- a/rust/copybook-reader/tests/resources/copybooks/types.cpy
+++ b/rust/copybook-reader/tests/resources/copybooks/types.cpy
@@ -14,3 +14,5 @@
            05 PIC-NUM-COMP PIC 9(2) COMP.
            05 PIC-NUM-COMP-3 PIC 9(2) COMP-3.
            05 PIC-DECIMAL PIC 9(6)V9(2).
+           05 EXPLICIT-DECIMAL PIC 9(6).9(2).
+           05 PIC-DECIMAL PIC S9(6)V9(2).

--- a/rust/copybook-reader/tests/resources/copybooks/types.cpy
+++ b/rust/copybook-reader/tests/resources/copybooks/types.cpy
@@ -1,14 +1,13 @@
        01 RECORD-R.
-           05 NINE-NUMBER 99.
-           05 ONE-NINE-NUMBER 9.
-           05 TWO-NINE-NUMBER 9(2).
-           05 ALPHA aaa.
-           05 ALPHA-PAREN a(3).
-           05 ALPHA-NUM xxxx.
-           05 ALPHA-NUM-PAREN x(4).
-           05 DECIMAL v(3). *> can store .175
-           05 SIGNED-NUM s9(2). *> examples -76
-           05 ASSUMED-DECIMAL p9. *> .6
+           05 NINE-NUMBER PIC 99.
+           05 TWO-NINE-NUMBER PIC 9(2).
+           05 ALPHA PIC aaa.
+           05 ALPHA-PAREN PIC a(3).
+           05 ALPHA-NUM PIC xxxx.
+           05 ALPHA-NUM-PAREN PIC x(4).
+           05 DECIMAL PIC 9(2)v9(3). *> can store .175
+           05 SIGNED-NUM PIC s9(2). *> examples -76
+           05 ASSUMED-DECIMAL PIC p9. *> .6
            05 PICTURE-ALPHA PIC X(10).
            05 PICTURE-CHAR PIC X.
            05 PICTURE-NUM PIC 9(2).

--- a/rust/copybook-reader/tests/resources/copybooks/types.cpy
+++ b/rust/copybook-reader/tests/resources/copybooks/types.cpy
@@ -5,9 +5,9 @@
            05 ALPHA-PAREN PIC a(3).
            05 ALPHA-NUM PIC xxxx.
            05 ALPHA-NUM-PAREN PIC x(4).
-           05 DECIMAL PIC 9(2)v9(3). *> can store .175
-           05 SIGNED-NUM PIC s9(2). *> examples -76
-           05 ASSUMED-DECIMAL PIC p9. *> .6
+           05 DECIMAL PIC 9(2)v9(3).
+           05 SIGNED-NUM PIC s9(2).
+           05 ASSUMED-DECIMAL PIC p9.
            05 PICTURE-ALPHA PIC X(10).
            05 PICTURE-CHAR PIC X.
            05 PICTURE-NUM PIC 9(2).
@@ -16,3 +16,4 @@
            05 PIC-DECIMAL PIC 9(6)V9(2).
            05 EXPLICIT-DECIMAL PIC 9(6).9(2).
            05 PIC-DECIMAL PIC S9(6)V9(2).
+           05 COMP-2-FIELD COMP-2.


### PR DESCRIPTION
closes #14 

### Changes
- Creates data type module with Structs/Enums to describe COBOL data types
- Adds DataTypeEnum to FieldDefinition
- Adds rule parsers to parse data types into DataTypeEnum variants
- Adds integration test for COBOL data types
- Updates Copybook Definition Display trait to use indentation

### Context For Reviewers
These changes should allow the copybook parser to handle different data types for fields.

I did add a lot of notes about my understanding of the different data types to `data_type.rs` which is based on tweaking a small cobol program and these references:
 - [cobol data types](https://www.tutorialspoint.com/cobol/cobol_data_types.htm)
 - [comp clause](https://www.techagilist.com/mainframe/usage-comp-declaration/)
 - [decimal point](https://www.mainframestechhelp.com/tutorials/cobol/assumed-decimal-point-data-type.htm)
 - [sign overpunch](https://support.hpe.com/hpesc/public/docDisplay?docId=c02258569&docLocale=en_US)
 - [floating types](https://www.cs.cornell.edu/~tomf/notes/cps104/floating.html)

### Testing
added tests are passing

### Code Change CheckList

- [X] Code runs without errors.
- [X] Added/Updated tests for feature.
- [X] fixed or suppressed any linting warnings.
- [X] Added relevant documentation to methods, classes, markdown.